### PR TITLE
fix: guard against null target_yield in history and add /beans nav link

### DIFF
--- a/app/routers/history.py
+++ b/app/routers/history.py
@@ -47,7 +47,7 @@ def _build_shot_dicts(
 
     shots = []
     for m in measurements:
-        brew_ratio = round(m.target_yield / m.dose_in, 2) if m.dose_in else None
+        brew_ratio = round(m.target_yield / m.dose_in, 2) if m.dose_in and m.target_yield else None
         tags = []
         if m.flavor_tags:
             try:

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -48,6 +48,7 @@
         <!-- Nav links -->
         <ul class="menu px-4 gap-1">
           <li><a href="/brew" class="text-base font-semibold min-h-12">Let's Brew</a></li>
+          <li><a href="/beans" class="text-base font-semibold min-h-12">Beans</a></li>
           <li><a href="/equipment" class="text-base font-semibold min-h-12">Equipment</a></li>
           <li><a href="/history" class="text-base font-semibold min-h-12">History</a></li>
           <li><a href="/insights" class="text-base font-semibold min-h-12">Insights</a></li>


### PR DESCRIPTION
## Summary

- **Fix `/history` 500 error** — `_build_shot_dicts()` in `app/routers/history.py:50` now guards against `target_yield` being `None` before computing the brew ratio. Non-espresso brew methods (french-press, cold-brew, etc.) store `target_yield=None`, which caused a `TypeError` on division.
- **Add `/beans` to sidebar navigation** — `app/templates/base.html` was missing a nav link to the Beans page, even though multiple routes redirect users there (e.g. when no active bean is selected). Added between "Let's Brew" and "Equipment".

Closes #5

## Testing

All 413 tests pass.