### PR TITLE
feat: enforce grinder bounds in optimizer and support hierarchical dial notation

### DIFF
--- a/app/models/equipment.py
+++ b/app/models/equipment.py
@@ -1,6 +1,8 @@
+import json
 import uuid
+from typing import Optional
 
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, String, Table, func
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, String, Table, Text, func
 from sqlalchemy.orm import relationship
 
 from app.database import Base
@@ -34,12 +36,143 @@ class Grinder(Base):
 
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     name = Column(String, nullable=False)
-    dial_type = Column(String, nullable=False, default="stepless")  # "stepped" or "stepless"
-    step_size = Column(Float, nullable=True)  # only meaningful when dial_type="stepped"
-    min_value = Column(Float, nullable=True)  # minimum grind setting
-    max_value = Column(Float, nullable=True)  # maximum grind setting
+
+    # ── Multi-ring grind dial columns ───────────────────────────────────
+    display_format = Column(String, nullable=False, default="decimal")
+    # Dial notation: "decimal", "x.y", "x.y.z"
+
+    ring_sizes_json = Column(Text, nullable=True)
+    # JSON-serialized list of [min, max, step] tuples per ring.
+    # step=None for continuous.  Example: [[0, 50, null]] or [[0, 4, 1], [0, 5, 1], [0, 10, 1]]
+
     is_retired = Column(Boolean, nullable=False, default=False)
     created_at = Column(DateTime, server_default=func.now())
+
+    def __init__(self, **kwargs):
+        # Handle ring_sizes convenience kwarg -> serialize to ring_sizes_json
+        ring_sizes = kwargs.pop("ring_sizes", None)
+        # Set Python-side defaults for new columns
+        kwargs.setdefault("display_format", "decimal")
+        super().__init__(**kwargs)
+        if ring_sizes is not None:
+            self.ring_sizes = ring_sizes
+
+    # ── ring_sizes JSON property ─────────────────────────────────────────
+
+    @property
+    def ring_sizes(self) -> Optional[list[tuple]]:
+        """Deserialize ring_sizes_json into a list of (min, max, step) tuples."""
+        if self.ring_sizes_json is None:
+            return None
+        raw = json.loads(self.ring_sizes_json)
+        return [tuple(r) for r in raw]
+
+    @ring_sizes.setter
+    def ring_sizes(self, value: Optional[list]) -> None:
+        """Serialize a list of (min, max, step) tuples to JSON."""
+        if value is None:
+            self.ring_sizes_json = None
+        else:
+            self.ring_sizes_json = json.dumps([list(r) for r in value])
+
+    # ── Helper methods ───────────────────────────────────────────────────
+
+    def _ring_position_counts(self) -> list[int]:
+        """Number of discrete positions per ring: max - min + 1 (for stepped rings)."""
+        rings = self.ring_sizes
+        if rings is None:
+            return []
+        return [int(r[1] - r[0] + 1) for r in rings]
+
+    def linear_bounds(self) -> Optional[tuple[float, float]]:
+        """Compute linearized (min, max) from ring_sizes.
+
+        For a single continuous ring, returns (ring_min, ring_max).
+        For multi-ring or single stepped ring, returns (0, total_positions - 1).
+        Returns None if ring_sizes is not set.
+        """
+        rings = self.ring_sizes
+        if rings is None:
+            return None
+
+        if len(rings) == 1:
+            # Single ring: linear range equals the ring's own range
+            return (float(rings[0][0]), float(rings[0][1]))
+
+        # Multi-ring: total positions = product of per-ring position counts
+        counts = self._ring_position_counts()
+        total = 1
+        for c in counts:
+            total *= c
+        return (0.0, float(total - 1))
+
+    def finest_step(self) -> Optional[float]:
+        """Return the smallest step size across all rings, or None if any ring is continuous."""
+        rings = self.ring_sizes
+        if rings is None:
+            return None
+        steps = [r[2] for r in rings]
+        if any(s is None for s in steps):
+            return None
+        return float(min(steps))
+
+    def to_display(self, value: float) -> str:
+        """Convert a linear value to display notation.
+
+        For decimal format (single ring): returns str(value), dropping .0 for whole numbers
+        when the ring is stepped.
+        For multi-ring formats (x.y, x.y.z): decomposes the linear integer into
+        per-ring positions using mixed-radix decomposition.
+        """
+        rings = self.ring_sizes
+        if rings is None:
+            return str(value)
+
+        if len(rings) == 1:
+            # Single ring — decimal display
+            step = rings[0][2]
+            if step is not None and value == int(value):
+                return str(int(value))
+            return str(value)
+
+        # Multi-ring: mixed-radix decomposition (most significant ring first)
+        counts = self._ring_position_counts()
+        linear_int = int(value)
+        parts: list[int] = []
+        for i in range(len(counts) - 1, -1, -1):
+            parts.append(linear_int % counts[i])
+            linear_int //= counts[i]
+        parts.reverse()
+
+        # Add ring minimums to each position
+        result = [str(parts[i] + int(rings[i][0])) for i in range(len(rings))]
+        return ".".join(result)
+
+    def from_display(self, text: str) -> float:
+        """Parse display notation to a linear value.
+
+        For decimal format (single ring): parses as float.
+        For multi-ring formats: computes linear value from per-ring positions.
+        """
+        rings = self.ring_sizes
+        if rings is None:
+            return float(text)
+
+        if len(rings) == 1:
+            return float(text)
+
+        # Multi-ring: parse parts and compute linear value
+        parts = text.split(".")
+        counts = self._ring_position_counts()
+        linear = 0
+        for i, part_str in enumerate(parts):
+            position = int(part_str) - int(rings[i][0])  # subtract ring minimum
+            # Multiply by product of all subsequent ring counts
+            multiplier = 1
+            for j in range(i + 1, len(counts)):
+                multiplier *= counts[j]
+            linear += position * multiplier
+        return float(linear)
 
 
 class Brewer(Base):

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -119,11 +119,22 @@ def _compute_comparison(db: Session) -> list[dict]:
         best = max(non_failed, key=lambda m: m.taste)
         shot_count = len(db.query(Measurement).filter(Measurement.bean_id == bean.id).all())
 
+        # Format grind_setting in native notation using the shot's setup grinder
+        grind_display = str(best.grind_setting) if best.grind_setting is not None else None
+        if best.brew_setup and best.brew_setup.grinder and best.grind_setting is not None:
+            grinder = best.brew_setup.grinder
+            if hasattr(grinder, "to_display"):
+                try:
+                    grind_display = grinder.to_display(float(best.grind_setting))
+                except (ValueError, TypeError):
+                    pass
+
         comparison.append(
             {
                 "bean_name": bean.name,
                 "taste": best.taste,
                 "grind_setting": best.grind_setting,
+                "grind_display": grind_display,
                 "temperature": best.temperature,
                 "preinfusion_pressure_pct": best.preinfusion_pressure_pct,
                 "dose_in": best.dose_in,

--- a/app/routers/brew.py
+++ b/app/routers/brew.py
@@ -306,6 +306,7 @@ async def trigger_recommend(request: Request, db: Session = Depends(get_db)):
     campaign_key = _get_campaign_key(bean, active_setup)
     method = _get_method_from_setup(active_setup)
     brewer = active_setup.brewer if active_setup else None
+    grinder = active_setup.grinder if active_setup else None
 
     optimizer = request.app.state.optimizer
 
@@ -324,6 +325,7 @@ async def trigger_recommend(request: Request, db: Session = Depends(get_db)):
         target_bean=bean,
         db=db,
         brewer=brewer,
+        grinder=grinder,
     )
 
     # Compute recommendation insights (explore vs exploit explanation + predicted taste)
@@ -333,6 +335,15 @@ async def trigger_recommend(request: Request, db: Session = Depends(get_db)):
     rec["insights"] = insights
     rec["method"] = method
     rec["setup_id"] = str(active_setup.id) if active_setup else None
+
+    # Format grind_setting for display in native notation (e.g. "2.3.7" for multi-ring)
+    if grinder and hasattr(grinder, "to_display") and "grind_setting" in rec:
+        try:
+            rec["grind_display"] = grinder.to_display(float(rec["grind_setting"]))
+        except (ValueError, TypeError):
+            rec["grind_display"] = str(rec["grind_setting"])
+    elif "grind_setting" in rec:
+        rec["grind_display"] = str(rec["grind_setting"])
 
     # Retrieve transfer metadata (set on first campaign creation if transfer learning applied)
     transfer_metadata = optimizer.get_transfer_metadata(campaign_key)
@@ -367,6 +378,21 @@ async def show_recommendation(
     insights = rec.get("insights", {})
     transfer_metadata = rec.get("transfer_metadata")
 
+    # Resolve grinder from active setup for display formatting
+    active_setup = _get_active_setup(request, db)
+    grinder = active_setup.grinder if active_setup else None
+
+    # Ensure grind_display is present (may already be set by trigger_recommend,
+    # but re-derive for direct-link GET requests)
+    if "grind_display" not in rec and "grind_setting" in rec:
+        if grinder and hasattr(grinder, "to_display"):
+            try:
+                rec["grind_display"] = grinder.to_display(float(rec["grind_setting"]))
+            except (ValueError, TypeError):
+                rec["grind_display"] = str(rec["grind_setting"])
+        else:
+            rec["grind_display"] = str(rec["grind_setting"])
+
     # Pass param_defs for generic hidden input rendering in template
     param_defs = PARAMETER_REGISTRY.get(method, PARAMETER_REGISTRY["espresso"])
 
@@ -386,6 +412,7 @@ async def show_recommendation(
             "param_short_labels": PARAM_SHORT_LABELS,
             "param_descriptions": PARAM_DESCRIPTIONS,
             "method": method,
+            "grinder": grinder,
         },
     )
 
@@ -417,9 +444,26 @@ async def record_measurement(
     # Extract all recognized param values from form
     params = _extract_params_from_form(method, form_data)
 
+    # For manual brews, resolve grinder once for display conversion + bounds validation
+    grinder_for_manual = None
+    if is_manual:
+        active_setup_for_grinder = _get_active_setup(request, db)
+        grinder_for_manual = active_setup_for_grinder.grinder if active_setup_for_grinder else None
+
+    # For manual brews with a multi-ring grinder, convert grind_setting from
+    # display notation (e.g. "2.3.7") to linear value before storing.
+    if is_manual and "grind_setting" in params:
+        if grinder_for_manual and hasattr(grinder_for_manual, "from_display"):
+            raw_grind = form_data.get("grind_setting", "")
+            if raw_grind and "." in str(raw_grind) and grinder_for_manual.display_format in ("x.y", "x.y.z"):
+                try:
+                    params["grind_setting"] = grinder_for_manual.from_display(str(raw_grind))
+                except (ValueError, TypeError):
+                    pass  # Fallback: keep the float-parsed value from _extract_params_from_form
+
     # Validate manual brews against bean parameter bounds
     if is_manual:
-        bounds = _resolve_bounds(bean.parameter_overrides, method=method)
+        bounds = _resolve_bounds(bean.parameter_overrides, method=method, grinder=grinder_for_manual)
         violations = []
         for param, value in params.items():
             if param not in bounds:
@@ -525,6 +569,7 @@ async def record_measurement(
         campaign_key = make_campaign_key(str(bean.id), method, brew_setup_id)
         active_setup_for_record = _get_active_setup(request, db)
         brewer_for_record = active_setup_for_record.brewer if active_setup_for_record else None
+        grinder_for_record = active_setup_for_record.grinder if active_setup_for_record else None
         measurement_data = dict(params)
         measurement_data["taste"] = taste
         optimizer.add_measurement(
@@ -534,6 +579,7 @@ async def record_measurement(
             method=method,
             target_bean_id=str(bean.id),
             brewer=brewer_for_record,
+            grinder=grinder_for_record,
         )
 
     # Clean up pending recommendation from DB
@@ -552,14 +598,24 @@ async def show_best(request: Request, db: Session = Depends(get_db)):
     active_setup = _get_active_setup(request, db)
     method = _get_method_from_setup(active_setup)
     brewer = active_setup.brewer if active_setup else None
+    grinder = active_setup.grinder if active_setup else None
 
     best = _best_measurement(bean.id, db)
 
     ratio = None
     best_session_id = None
+    grind_display = None
     if best:
         ratio = _brew_ratio(best.dose_in, best.target_yield)
         best_session_id = str(uuid.uuid4())
+        # Format grind_setting for display
+        if grinder and hasattr(grinder, "to_display") and best.grind_setting is not None:
+            try:
+                grind_display = grinder.to_display(float(best.grind_setting))
+            except (ValueError, TypeError):
+                grind_display = str(best.grind_setting)
+        elif best.grind_setting is not None:
+            grind_display = str(best.grind_setting)
 
     # Get param_defs filtered by brewer capabilities for dynamic hidden input rendering
     from app.services.parameter_registry import get_param_columns
@@ -583,6 +639,8 @@ async def show_best(request: Request, db: Session = Depends(get_db)):
             "param_short_labels": PARAM_SHORT_LABELS,
             "param_descriptions": PARAM_DESCRIPTIONS,
             "method": method,
+            "grinder": grinder,
+            "grind_display": grind_display,
         },
     )
 
@@ -597,7 +655,8 @@ async def manual_brew(request: Request, db: Session = Depends(get_db)):
     active_setup = _get_active_setup(request, db)
     method = _get_method_from_setup(active_setup)
     brewer = active_setup.brewer if active_setup else None
-    bounds = _resolve_bounds(bean.parameter_overrides, method=method)
+    grinder = active_setup.grinder if active_setup else None
+    bounds = _resolve_bounds(bean.parameter_overrides, method=method, grinder=grinder)
     best = _best_measurement(bean.id, db)
 
     # Get the active param columns for this method+brewer combo
@@ -642,6 +701,14 @@ async def manual_brew(request: Request, db: Session = Depends(get_db)):
     manual_session_id = str(uuid.uuid4())
     setup_id = str(active_setup.id) if active_setup else None
 
+    # Format prefill grind_setting for display if grinder has multi-ring format
+    grind_display_prefill = None
+    if "grind_setting" in prefill and grinder and hasattr(grinder, "to_display"):
+        try:
+            grind_display_prefill = grinder.to_display(float(prefill["grind_setting"]))
+        except (ValueError, TypeError):
+            grind_display_prefill = str(prefill["grind_setting"])
+
     return templates.TemplateResponse(
         request,
         "brew/manual.html",
@@ -649,10 +716,12 @@ async def manual_brew(request: Request, db: Session = Depends(get_db)):
             "active_bean": bean,
             "active_setup": active_setup,
             "brewer": brewer,
+            "grinder": grinder,
             "method": method,
             "setup_id": setup_id,
             "bounds": bounds,
             "prefill": prefill,
+            "grind_display_prefill": grind_display_prefill,
             "manual_session_id": manual_session_id,
             "param_defs": param_defs,
             "param_labels": PARAM_LABELS,
@@ -747,6 +816,7 @@ async def rebuild_campaign_route(
 
     active_setup = _get_active_setup(request, db)
     brewer = active_setup.brewer if active_setup else None
+    grinder = active_setup.grinder if active_setup else None
 
     optimizer = request.app.state.optimizer
     optimizer.accept_rebuild(
@@ -754,6 +824,7 @@ async def rebuild_campaign_route(
         method=method,
         brewer=brewer,
         overrides=bean.parameter_overrides,
+        grinder=grinder,
     )
 
     # Redirect to trigger a fresh recommendation with the new params

--- a/app/routers/brew.py
+++ b/app/routers/brew.py
@@ -441,9 +441,6 @@ async def record_measurement(
     is_failed_raw = form_data.get("is_failed", "")
     failed = is_failed_raw in ("true", "1", "on")
 
-    # Extract all recognized param values from form
-    params = _extract_params_from_form(method, form_data)
-
     # For manual brews, resolve grinder once for display conversion + bounds validation
     grinder_for_manual = None
     if is_manual:
@@ -451,15 +448,18 @@ async def record_measurement(
         grinder_for_manual = active_setup_for_grinder.grinder if active_setup_for_grinder else None
 
     # For manual brews with a multi-ring grinder, convert grind_setting from
-    # display notation (e.g. "2.3.7") to linear value before storing.
-    if is_manual and "grind_setting" in params:
-        if grinder_for_manual and hasattr(grinder_for_manual, "from_display"):
-            raw_grind = form_data.get("grind_setting", "")
-            if raw_grind and "." in str(raw_grind) and grinder_for_manual.display_format in ("x.y", "x.y.z"):
-                try:
-                    params["grind_setting"] = grinder_for_manual.from_display(str(raw_grind))
-                except (ValueError, TypeError):
-                    pass  # Fallback: keep the float-parsed value from _extract_params_from_form
+    # display notation (e.g. "2.3.7") to linear value BEFORE float parsing,
+    # because "2.3.7" is not a valid float literal.
+    if is_manual and grinder_for_manual and hasattr(grinder_for_manual, "from_display"):
+        raw_grind = form_data.get("grind_setting", "")
+        if raw_grind and grinder_for_manual.display_format in ("x.y", "x.y.z"):
+            try:
+                form_data["grind_setting"] = str(grinder_for_manual.from_display(str(raw_grind)))
+            except (ValueError, TypeError):
+                pass  # Fallback: let _extract_params_from_form try float()
+
+    # Extract all recognized param values from form
+    params = _extract_params_from_form(method, form_data)
 
     # Validate manual brews against bean parameter bounds
     if is_manual:

--- a/app/routers/equipment.py
+++ b/app/routers/equipment.py
@@ -38,6 +38,33 @@ def _parse_float(value: str) -> Optional[float]:
         return None
 
 
+def _parse_ring_sizes(display_format: str, form) -> list:
+    """Build ring_sizes list from form data based on display_format.
+
+    For 'decimal' format: reads ring_min, ring_max, ring_step (step empty = None = continuous).
+    For 'x.y' format: reads ring_0_min/max/step and ring_1_min/max/step.
+    For 'x.y.z' format: same pattern for 3 rings.
+    """
+    if display_format == "x.y":
+        ring_count = 2
+    elif display_format == "x.y.z":
+        ring_count = 3
+    else:
+        # decimal — single ring
+        ring_min = _parse_float(form.get("ring_min", "")) or 0.0
+        ring_max = _parse_float(form.get("ring_max", "")) or 50.0
+        ring_step = _parse_float(form.get("ring_step", ""))
+        return [[ring_min, ring_max, ring_step]]
+
+    rings = []
+    for i in range(ring_count):
+        r_min = _parse_float(form.get(f"ring_{i}_min", "")) or 0.0
+        r_max = _parse_float(form.get(f"ring_{i}_max", "")) or 50.0
+        r_step = _parse_float(form.get(f"ring_{i}_step", ""))
+        rings.append([r_min, r_max, r_step])
+    return rings
+
+
 @router.get("", response_class=HTMLResponse)
 async def equipment_index(
     request: Request,
@@ -115,19 +142,17 @@ async def equipment_index(
 async def create_grinder(
     request: Request,
     name: str = Form(...),
-    dial_type: str = Form("stepless"),
-    step_size: str = Form(""),
-    min_value: str = Form(""),
-    max_value: str = Form(""),
+    display_format: str = Form("decimal"),
     db: Session = Depends(get_db),
 ):
-    """Create a new grinder."""
+    """Create a new grinder with ring-based dial configuration."""
+    form = await request.form()
+    ring_sizes = _parse_ring_sizes(display_format, form)
+
     grinder = Grinder(
         name=name.strip(),
-        dial_type=dial_type,
-        step_size=_parse_float(step_size) if dial_type == "stepped" else None,
-        min_value=_parse_float(min_value),
-        max_value=_parse_float(max_value),
+        display_format=display_format,
+        ring_sizes=ring_sizes,
     )
     db.add(grinder)
     db.commit()
@@ -166,10 +191,7 @@ async def update_grinder(
     request: Request,
     grinder_id: str,
     name: str = Form(...),
-    dial_type: str = Form("stepless"),
-    step_size: str = Form(""),
-    min_value: str = Form(""),
-    max_value: str = Form(""),
+    display_format: str = Form("decimal"),
     db: Session = Depends(get_db),
 ):
     """Update an existing grinder."""
@@ -177,11 +199,12 @@ async def update_grinder(
     if not grinder:
         return RedirectResponse(url="/equipment", status_code=303)
 
+    form = await request.form()
+    ring_sizes = _parse_ring_sizes(display_format, form)
+
     grinder.name = name.strip()
-    grinder.dial_type = dial_type
-    grinder.step_size = _parse_float(step_size) if dial_type == "stepped" else None
-    grinder.min_value = _parse_float(min_value)
-    grinder.max_value = _parse_float(max_value)
+    grinder.display_format = display_format
+    grinder.ring_sizes = ring_sizes
     db.commit()
 
     return RedirectResponse(url="/equipment", status_code=303)

--- a/app/routers/history.py
+++ b/app/routers/history.py
@@ -54,12 +54,24 @@ def _build_shot_dicts(
                 tags = json.loads(m.flavor_tags)
             except (ValueError, TypeError):
                 tags = []
+
+        # Format grind_setting in native notation using the shot's setup grinder
+        grind_display = str(m.grind_setting) if m.grind_setting is not None else None
+        if m.brew_setup and m.brew_setup.grinder and m.grind_setting is not None:
+            grinder = m.brew_setup.grinder
+            if hasattr(grinder, "to_display"):
+                try:
+                    grind_display = grinder.to_display(float(m.grind_setting))
+                except (ValueError, TypeError):
+                    pass
+
         shots.append(
             {
                 "id": m.id,
                 "created_at": m.created_at,
                 "taste": m.taste,
                 "grind_setting": m.grind_setting,
+                "grind_display": grind_display,
                 "is_failed": m.is_failed,
                 "is_manual": getattr(m, "is_manual", False) or False,
                 "notes": m.notes,
@@ -97,11 +109,22 @@ def _load_shot_detail(shot_id: int, db: Session) -> dict:
         except (ValueError, TypeError):
             tags = []
 
+    # Format grind_setting in native notation using the shot's setup grinder
+    grind_display = str(m.grind_setting) if m.grind_setting is not None else None
+    if m.brew_setup and m.brew_setup.grinder and m.grind_setting is not None:
+        grinder = m.brew_setup.grinder
+        if hasattr(grinder, "to_display"):
+            try:
+                grind_display = grinder.to_display(float(m.grind_setting))
+            except (ValueError, TypeError):
+                pass
+
     return {
         "id": m.id,
         "created_at": m.created_at,
         "taste": m.taste,
         "grind_setting": m.grind_setting,
+        "grind_display": grind_display,
         "temperature": m.temperature,
         "preinfusion_pressure_pct": m.preinfusion_pressure_pct,
         "dose_in": m.dose_in,
@@ -294,11 +317,22 @@ async def shot_edit_save(
     )
 
     # Build plain row dict (matching _build_shot_dicts structure)
+    # Format grind_setting in native notation for the row
+    row_grind_display = str(m.grind_setting) if m.grind_setting is not None else None
+    if m.brew_setup and m.brew_setup.grinder and m.grind_setting is not None:
+        grinder = m.brew_setup.grinder
+        if hasattr(grinder, "to_display"):
+            try:
+                row_grind_display = grinder.to_display(float(m.grind_setting))
+            except (ValueError, TypeError):
+                pass
+
     row_shot = {
         "id": m.id,
         "created_at": m.created_at,
         "taste": m.taste,
         "grind_setting": m.grind_setting,
+        "grind_display": row_grind_display,
         "is_failed": m.is_failed,
         "is_manual": getattr(m, "is_manual", False) or False,
         "notes": m.notes,

--- a/app/services/optimizer.py
+++ b/app/services/optimizer.py
@@ -105,9 +105,19 @@ def _resolve_bounds(
             if param in bounds and isinstance(spec, dict):
                 lo, hi = bounds[param]
                 bounds[param] = (spec.get("min", lo), spec.get("max", hi))
-    # Clip grind_setting to grinder's physical range
+    # For grind_setting with a grinder: use percentage-based suggested range,
+    # then clip to physical limits.
     if grinder is not None and "grind_setting" in bounds:
-        grinder_bounds = grinder.linear_bounds() if hasattr(grinder, 'linear_bounds') else None
+        from app.services.parameter_registry import suggest_grind_range
+
+        suggested = suggest_grind_range(grinder, method)
+        if suggested is not None:
+            # Use suggested range unless bean overrides were applied
+            has_grind_override = overrides and "grind_setting" in overrides
+            if not has_grind_override:
+                bounds["grind_setting"] = suggested
+        # Always clip to grinder's physical limits
+        grinder_bounds = grinder.linear_bounds() if hasattr(grinder, "linear_bounds") else None
         if grinder_bounds is not None:
             g_lo, g_hi = grinder_bounds
             lo, hi = bounds["grind_setting"]

--- a/app/services/optimizer.py
+++ b/app/services/optimizer.py
@@ -56,9 +56,36 @@ def _round_value(value: float, step: float) -> float:
     return round(round(value / step) * step, 2)
 
 
+def snap_grind_to_step(value: float, grinder) -> float:
+    """Snap a grind setting value to the nearest valid step for a stepped grinder.
+
+    If grinder is None or continuous (finest_step() is None), return value unchanged.
+    Otherwise, snap to nearest valid step within grinder bounds.
+
+    Args:
+        value: The grind setting value to snap.
+        grinder: Grinder ORM instance, or None.
+
+    Returns:
+        Snapped grind setting value.
+    """
+    if grinder is None:
+        return value
+    bounds = grinder.linear_bounds()
+    if bounds is None:
+        return value
+    step = grinder.finest_step()
+    if step is None:
+        return value
+    min_val, max_val = bounds
+    snapped = round((value - min_val) / step) * step + min_val
+    return max(min_val, min(max_val, round(snapped, 2)))
+
+
 def _resolve_bounds(
     overrides: dict | None,
     method: str = "espresso",
+    grinder=None,
 ) -> dict[str, tuple[float, float]]:
     """Merge per-bean overrides onto default bounds.
 
@@ -67,6 +94,7 @@ def _resolve_bounds(
                    Only parameters that differ from defaults need to be present.
                    None or {} means "use all defaults".
         method: Brew method name — determines which default bounds to use.
+        grinder: Grinder ORM instance for physical range clipping (or None).
 
     Returns:
         Complete bounds dict for all continuous parameters of the given method.
@@ -77,6 +105,13 @@ def _resolve_bounds(
             if param in bounds and isinstance(spec, dict):
                 lo, hi = bounds[param]
                 bounds[param] = (spec.get("min", lo), spec.get("max", hi))
+    # Clip grind_setting to grinder's physical range
+    if grinder is not None and "grind_setting" in bounds:
+        grinder_bounds = grinder.linear_bounds() if hasattr(grinder, 'linear_bounds') else None
+        if grinder_bounds is not None:
+            g_lo, g_hi = grinder_bounds
+            lo, hi = bounds["grind_setting"]
+            bounds["grind_setting"] = (max(lo, g_lo), min(hi, g_hi))
     return bounds
 
 
@@ -183,6 +218,7 @@ class OptimizerService:
         overrides: dict | None = None,
         method: str = "espresso",
         brewer=None,
+        grinder=None,
     ) -> Campaign:
         """Create a hybrid BayBE campaign for the given method.
 
@@ -191,8 +227,9 @@ class OptimizerService:
                        e.g. {"grind_setting": {"min": 18.0, "max": 22.0}}
             method: Brew method — determines parameter set (espresso vs pour-over).
             brewer: Brewer ORM object (or None for Tier 1 / legacy campaigns).
+            grinder: Grinder ORM object for physical range clipping (or None).
         """
-        parameters = build_parameters_for_setup(method, brewer=brewer, overrides=overrides)
+        parameters = build_parameters_for_setup(method, brewer=brewer, overrides=overrides, grinder=grinder)
         searchspace = SearchSpace.from_product(parameters=parameters)
         target = NumericalTarget(name="taste")
         objective = SingleTargetObjective(target=target)
@@ -207,6 +244,7 @@ class OptimizerService:
         target_bean: "Bean | None" = None,
         db: "Session | None" = None,
         brewer=None,
+        grinder=None,
     ) -> Campaign:
         """Get campaign from cache, DB, or create fresh. Thread-safe.
 
@@ -224,12 +262,13 @@ class OptimizerService:
             target_bean: Bean ORM object for transfer learning lookup (optional).
             db: SQLAlchemy Session for similarity queries (optional).
             brewer: Brewer ORM object for capability-gated parameter selection (optional).
+            grinder: Grinder ORM object for physical range clipping (optional).
         """
         # Import here to avoid circular imports at module load time
         from app.services.similarity import SimilarityService
         from app.services.transfer_learning import build_transfer_campaign
 
-        current_fp = _bounds_fingerprint(_resolve_bounds(overrides, method))
+        current_fp = _bounds_fingerprint(_resolve_bounds(overrides, method, grinder=grinder))
 
         with self._lock:
             # Load from DB if not cached
@@ -258,7 +297,7 @@ class OptimizerService:
                                 }
 
                     if campaign is None:
-                        campaign = self._create_fresh_campaign(overrides, method, brewer)
+                        campaign = self._create_fresh_campaign(overrides, method, brewer, grinder=grinder)
 
                     self._cache[campaign_key] = campaign
                     self._fingerprints[campaign_key] = current_fp
@@ -272,7 +311,7 @@ class OptimizerService:
             if stored_fp and stored_fp != current_fp:
                 old_campaign = self._cache[campaign_key]
                 measurements_df = old_campaign.measurements
-                new_campaign = self._create_fresh_campaign(overrides, method, brewer)
+                new_campaign = self._create_fresh_campaign(overrides, method, brewer, grinder=grinder)
                 if not measurements_df.empty:
                     param_cols = get_param_columns(method, brewer)
                     # For transfer campaigns the measurements include bean_task — filter to
@@ -318,6 +357,7 @@ class OptimizerService:
         target_bean: "Bean | None" = None,
         db: "Session | None" = None,
         brewer=None,
+        grinder=None,
     ) -> dict:
         """Generate a recommendation. Runs in thread pool (BayBE blocks 3-10s).
 
@@ -328,11 +368,13 @@ class OptimizerService:
             target_bean: Bean ORM object for transfer learning lookup (optional).
             db: SQLAlchemy Session for similarity queries (optional).
             brewer: Brewer ORM object for capability-gated parameter selection (optional).
+            grinder: Grinder ORM object for physical range clipping and step snapping (optional).
         """
 
         def _recommend():
             campaign = self.get_or_create_campaign(
-                campaign_key, overrides, method, target_bean=target_bean, db=db, brewer=brewer
+                campaign_key, overrides, method, target_bean=target_bean, db=db, brewer=brewer,
+                grinder=grinder,
             )
             with self._lock:
                 campaign.clear_cache()
@@ -345,6 +387,10 @@ class OptimizerService:
             for param, step in rounding.items():
                 if param in rec:
                     rec[param] = _round_value(float(rec[param]), step)
+
+            # Snap grind_setting to nearest valid step for stepped grinders
+            if grinder is not None and "grind_setting" in rec:
+                rec["grind_setting"] = snap_grind_to_step(float(rec["grind_setting"]), grinder)
 
             # Generate idempotency token
             rec["recommendation_id"] = str(uuid.uuid4())
@@ -360,6 +406,7 @@ class OptimizerService:
         method: str = "espresso",
         target_bean_id: str | None = None,
         brewer=None,
+        grinder=None,
     ) -> None:
         """Record a measurement. Runs synchronously (fast).
 
@@ -371,8 +418,9 @@ class OptimizerService:
             method: Brew method for parameter set selection.
             target_bean_id: Bean ID to set as bean_task for transfer learning campaigns.
             brewer: Brewer ORM object for capability-gated parameter selection (optional).
+            grinder: Grinder ORM object for physical range clipping (optional).
         """
-        campaign = self.get_or_create_campaign(campaign_key, overrides, method, brewer=brewer)
+        campaign = self.get_or_create_campaign(campaign_key, overrides, method, brewer=brewer, grinder=grinder)
         # Only include method-appropriate BayBE columns + taste
         param_cols = get_param_columns(method, brewer)
         baybe_data = {k: measurement[k] for k in param_cols + ["taste"] if k in measurement}
@@ -391,6 +439,7 @@ class OptimizerService:
         overrides: dict | None = None,
         method: str = "espresso",
         brewer=None,
+        grinder=None,
     ) -> Campaign:
         """Disaster recovery: rebuild campaign from measurement data.
 
@@ -400,8 +449,9 @@ class OptimizerService:
             overrides: Per-bean parameter range overrides.
             method: Brew method for parameter set selection.
             brewer: Brewer ORM object for capability-gated parameter selection (optional).
+            grinder: Grinder ORM object for physical range clipping (optional).
         """
-        campaign = self._create_fresh_campaign(overrides, method, brewer)
+        campaign = self._create_fresh_campaign(overrides, method, brewer, grinder=grinder)
         if not measurements_df.empty:
             param_cols = get_param_columns(method, brewer)
             baybe_cols = param_cols + ["taste"]
@@ -410,7 +460,7 @@ class OptimizerService:
                 measurements_df[available_cols],
                 numerical_measurements_must_be_within_tolerance=False,
             )
-        current_fp = _bounds_fingerprint(_resolve_bounds(overrides, method))
+        current_fp = _bounds_fingerprint(_resolve_bounds(overrides, method, grinder=grinder))
         new_param_fp = _param_set_fingerprint(method, brewer)
         with self._lock:
             self._cache[campaign_key] = campaign
@@ -573,6 +623,7 @@ class OptimizerService:
         method: str,
         brewer,
         overrides: dict | None = None,
+        grinder=None,
     ) -> Campaign:
         """Rebuild the campaign with the current brewer's parameter set.
 
@@ -585,6 +636,7 @@ class OptimizerService:
             method: Brew method name.
             brewer: Current Brewer ORM object.
             overrides: Per-bean parameter range overrides.
+            grinder: Grinder ORM object for physical range clipping (optional).
         """
         from app.models.campaign_state import CampaignState
 
@@ -601,7 +653,7 @@ class OptimizerService:
                 measurements_df = pd.DataFrame()
 
         # Build fresh campaign with new param set
-        new_campaign = self._create_fresh_campaign(overrides, method, brewer)
+        new_campaign = self._create_fresh_campaign(overrides, method, brewer, grinder=grinder)
         if not measurements_df.empty:
             new_param_cols = get_param_columns(method, brewer)
             required_cols = new_param_cols + ["taste"]
@@ -616,7 +668,7 @@ class OptimizerService:
                     numerical_measurements_must_be_within_tolerance=False,
                 )
 
-        current_fp = _bounds_fingerprint(_resolve_bounds(overrides, method))
+        current_fp = _bounds_fingerprint(_resolve_bounds(overrides, method, grinder=grinder))
         new_param_fp = _param_set_fingerprint(method, brewer)
 
         with self._lock:

--- a/app/services/parameter_registry.py
+++ b/app/services/parameter_registry.py
@@ -551,7 +551,10 @@ def build_parameters_for_setup(
     continue to work via Campaign.from_json() without going through this function.
 
     Priority for grind_setting bounds:
-      registry defaults -> bean overrides -> grinder clips (hard ceiling)
+      1. If grinder provided: suggest_grind_range() computes method-appropriate range
+         as a percentage of the grinder's linearized range, then bean overrides narrow it,
+         then grinder physical limits clip it.
+      2. If no grinder: registry defaults, then bean overrides.
 
     Args:
         method: Brew method (e.g. "espresso", "pour-over").
@@ -564,11 +567,14 @@ def build_parameters_for_setup(
     """
     param_defs = PARAMETER_REGISTRY.get(method, PARAMETER_REGISTRY["espresso"])
 
-    # Pre-compute grinder linear bounds for grind_setting clipping
+    # Pre-compute grinder bounds for grind_setting
     grinder_bounds = None
+    grinder_suggested = None
     if grinder is not None:
         if hasattr(grinder, "linear_bounds") and callable(grinder.linear_bounds):
             grinder_bounds = grinder.linear_bounds()
+        # Compute method-appropriate grind range as percentage of grinder's full range
+        grinder_suggested = suggest_grind_range(grinder, method)
 
     parameters = []
     for pdef in param_defs:
@@ -598,8 +604,21 @@ def build_parameters_for_setup(
                     lo = spec.get("min", lo)
                     hi = spec.get("max", hi)
 
-            # Clip grind_setting to grinder's physical range (hard ceiling)
-            if name == "grind_setting" and grinder_bounds is not None:
+            # For grind_setting with a grinder: use percentage-based range as base,
+            # then clip to physical limits. This ensures multi-ring grinders get
+            # method-appropriate ranges instead of registry defaults (which are on
+            # a different scale).
+            if name == "grind_setting" and grinder_suggested is not None:
+                # Use suggested range as base (unless bean overrides were applied)
+                if not (overrides and name in overrides):
+                    lo, hi = grinder_suggested
+                # Always clip to grinder's physical range
+                if grinder_bounds is not None:
+                    grinder_min, grinder_max = grinder_bounds
+                    lo = max(lo, grinder_min)
+                    hi = min(hi, grinder_max)
+            elif name == "grind_setting" and grinder_bounds is not None:
+                # No suggested range but have physical limits — just clip
                 grinder_min, grinder_max = grinder_bounds
                 lo = max(lo, grinder_min)
                 hi = min(hi, grinder_max)

--- a/app/services/parameter_registry.py
+++ b/app/services/parameter_registry.py
@@ -48,7 +48,7 @@ from baybe.parameters import CategoricalParameter, NumericalContinuousParameter
 
 # ---------------------------------------------------------------------------
 # Grind range percentages per brew method
-# Expressed as (low_pct, high_pct) of the grinder's full range (min_value..max_value)
+# Expressed as (low_pct, high_pct) of the grinder's linearized range
 # ---------------------------------------------------------------------------
 METHOD_GRIND_PERCENTAGES: dict[str, tuple[float, float]] = {
     "espresso": (0.15, 0.40),
@@ -542,6 +542,7 @@ def build_parameters_for_setup(
     method: str,
     brewer: Any = None,
     overrides: dict[str, dict[str, float]] | None = None,
+    grinder: Any = None,
 ) -> list:
     """Build BayBE parameter objects for the given method and brewer.
 
@@ -549,15 +550,25 @@ def build_parameters_for_setup(
     new campaigns.  Existing serialised campaigns with legacy params in their searchspace
     continue to work via Campaign.from_json() without going through this function.
 
+    Priority for grind_setting bounds:
+      registry defaults -> bean overrides -> grinder clips (hard ceiling)
+
     Args:
         method: Brew method (e.g. "espresso", "pour-over").
         brewer: Brewer ORM instance for capability gating, or None for backward compat.
         overrides: Per-param bound overrides, e.g. {"grind_setting": {"min": 18.0, "max": 22.0}}.
+        grinder: Grinder ORM instance for physical range clipping, or None.
 
     Returns:
         List of BayBE parameter objects (NumericalContinuousParameter or CategoricalParameter).
     """
     param_defs = PARAMETER_REGISTRY.get(method, PARAMETER_REGISTRY["espresso"])
+
+    # Pre-compute grinder linear bounds for grind_setting clipping
+    grinder_bounds = None
+    if grinder is not None:
+        if hasattr(grinder, "linear_bounds") and callable(grinder.linear_bounds):
+            grinder_bounds = grinder.linear_bounds()
 
     parameters = []
     for pdef in param_defs:
@@ -586,6 +597,13 @@ def build_parameters_for_setup(
                 if isinstance(spec, dict):
                     lo = spec.get("min", lo)
                     hi = spec.get("max", hi)
+
+            # Clip grind_setting to grinder's physical range (hard ceiling)
+            if name == "grind_setting" and grinder_bounds is not None:
+                grinder_min, grinder_max = grinder_bounds
+                lo = max(lo, grinder_min)
+                hi = min(hi, grinder_max)
+
             parameters.append(NumericalContinuousParameter(name=name, bounds=(lo, hi)))
 
     return parameters
@@ -667,10 +685,11 @@ def suggest_grind_range(grinder: Any, method: str) -> tuple[float, float] | None
     """Suggest a grind setting range for the given grinder and brew method.
 
     Uses METHOD_GRIND_PERCENTAGES to compute the range as a fraction of the
-    grinder's full range (grinder.min_value .. grinder.max_value).
+    grinder's linearized bounds (from grinder.linear_bounds()).
 
     Args:
-        grinder: Grinder ORM instance with min_value and max_value attributes.
+        grinder: Grinder ORM instance with linear_bounds() method (or legacy
+                 min_value/max_value attributes for backward compatibility).
         method: Brew method name.
 
     Returns:
@@ -679,12 +698,21 @@ def suggest_grind_range(grinder: Any, method: str) -> tuple[float, float] | None
     if grinder is None:
         return None
 
-    lo_val = getattr(grinder, "min_value", None)
-    hi_val = getattr(grinder, "max_value", None)
+    # Use linear_bounds() if available (new model), fall back to legacy attrs
+    bounds = None
+    if hasattr(grinder, "linear_bounds") and callable(grinder.linear_bounds):
+        bounds = grinder.linear_bounds()
+    if bounds is None:
+        # Fallback for mock objects / backward compatibility
+        lo_val = getattr(grinder, "min_value", None)
+        hi_val = getattr(grinder, "max_value", None)
+        if lo_val is not None and hi_val is not None:
+            bounds = (lo_val, hi_val)
 
-    if lo_val is None or hi_val is None:
+    if bounds is None:
         return None
 
+    lo_val, hi_val = bounds
     grind_range = hi_val - lo_val
     if grind_range <= 0:
         return None

--- a/app/templates/analytics/_comparison_table.html
+++ b/app/templates/analytics/_comparison_table.html
@@ -19,7 +19,7 @@
     <div class="recipe-grid">
       <div class="text-center p-2 bg-base-300/30 rounded">
         <span class="block text-xs text-base-content/60">Grind</span>
-        <span class="block font-semibold">{{ bean.grind_setting }}</span>
+        <span class="block font-semibold">{{ bean.grind_display if bean.grind_display is defined and bean.grind_display else bean.grind_setting }}</span>
       </div>
       <div class="text-center p-2 bg-base-300/30 rounded">
         <span class="block text-xs text-base-content/60">Temp</span>

--- a/app/templates/brew/_recipe_card.html
+++ b/app/templates/brew/_recipe_card.html
@@ -34,11 +34,20 @@
 {% endmacro %}
 
 <div class="recipe-params">
-  {# ── Grind Setting ──────────────────────────────────────────────── #}
+  {# ── Grind Setting (display in native notation if available) ───── #}
   {% if rec is mapping %}
-    {{ param_block('grind_setting', 'Grind', rec.grind_setting) }}
+    {% if rec.grind_display is defined and rec.grind_display is not none %}
+      {{ param_block('grind_setting', 'Grind', rec.grind_display) }}
+    {% else %}
+      {{ param_block('grind_setting', 'Grind', rec.grind_setting) }}
+    {% endif %}
   {% else %}
-    {{ param_block('grind_setting', 'Grind', rec.grind_setting) }}
+    {# ORM Measurement object — use grind_display if added to dict, else raw value #}
+    {% if grind_display is defined and grind_display is not none %}
+      {{ param_block('grind_setting', 'Grind', grind_display) }}
+    {% else %}
+      {{ param_block('grind_setting', 'Grind', rec.grind_setting) }}
+    {% endif %}
   {% endif %}
 
   {# ── Temperature ────────────────────────────────────────────────── #}

--- a/app/templates/brew/manual.html
+++ b/app/templates/brew/manual.html
@@ -102,6 +102,32 @@
         {% set pmax = bounds[pname][1] %}
         {% set pstep = pdef.rounding if pdef.rounding else 1.0 %}
         {% set pval = prefill[pname] if pname in prefill else ((pmin + pmax) / 2) %}
+
+        {# Special handling for grind_setting with multi-ring grinder #}
+        {% if pname == 'grind_setting' and grinder is defined and grinder and grinder.display_format is defined and grinder.display_format in ('x.y', 'x.y.z') %}
+        <div class="form-control mb-4">
+          <label class="label">
+            <span class="label-text">{{ plabel }}{{ info_icon(pname) }}
+              <span class="text-xs text-base-content/50 ml-1">({{ grinder.display_format }} format)</span>
+            </span>
+            {% set display_min = grinder.to_display(pmin) %}
+            {% set display_max = grinder.to_display(pmax) %}
+            <span class="label-text-alt">({{ display_min }}–{{ display_max }})</span>
+          </label>
+          <input
+            type="text"
+            class="input input-bordered w-full"
+            id="{{ pname }}"
+            name="{{ pname }}"
+            value="{{ grind_display_prefill if grind_display_prefill else pval }}"
+            placeholder="e.g. {{ grinder.display_format | replace('x', '2') | replace('y', '3') | replace('z', '7') }}"
+            data-param="{{ pname }}"
+          >
+          <label class="label">
+            <span class="label-text-alt text-base-content/50">Enter in {{ grinder.display_format }} notation (e.g. {{ grinder.display_format | replace('x', '2') | replace('y', '3') | replace('z', '7') }})</span>
+          </label>
+        </div>
+        {% else %}
         <div class="form-control mb-4">
           <label class="label">
             <span class="label-text">{{ plabel }}{{ info_icon(pname) }}</span>
@@ -132,6 +158,7 @@
             >
           </div>
         </div>
+        {% endif %}
         {% endif %}
 
         {% endif %}

--- a/app/templates/equipment/_grinder_card.html
+++ b/app/templates/equipment/_grinder_card.html
@@ -5,19 +5,24 @@
       <div>
         <h3 class="font-semibold">{{ grinder.name }}</h3>
         <div class="text-sm text-base-content/70 mt-1">
-          {% if grinder.dial_type == "stepped" %}
-            Stepped
-            {% if grinder.step_size is not none %}
-              · step {{ grinder.step_size }}
-            {% endif %}
-            {% if grinder.min_value is not none and grinder.max_value is not none %}
-              · {{ grinder.min_value }}–{{ grinder.max_value }}
+          {% if grinder.ring_sizes %}
+            {% if grinder.display_format == 'x.y' or grinder.display_format == 'x.y.z' %}
+              {{ grinder.display_format }} format
+              · {{ grinder.ring_sizes|length }} rings
+              {% set bounds = grinder.linear_bounds() %}
+              {% if bounds %}
+                · {{ grinder.to_display(bounds[0]) }}–{{ grinder.to_display(bounds[1]) }}
+              {% endif %}
+            {% else %}
+              {% if grinder.ring_sizes[0][2] is not none %}
+                Stepped · step {{ grinder.ring_sizes[0][2] }}
+              {% else %}
+                Stepless
+              {% endif %}
+              · {{ grinder.ring_sizes[0][0] }}–{{ grinder.ring_sizes[0][1] }}
             {% endif %}
           {% else %}
-            Stepless
-            {% if grinder.min_value is not none and grinder.max_value is not none %}
-              · range {{ grinder.min_value }}–{{ grinder.max_value }}
-            {% endif %}
+            No range configured
           {% endif %}
         </div>
       </div>

--- a/app/templates/equipment/_grinder_form.html
+++ b/app/templates/equipment/_grinder_form.html
@@ -29,73 +29,144 @@
   </div>
 
   <div class="form-control mb-4">
-    <label class="label"><span class="label-text">Dial Type</span></label>
-    <div class="flex gap-2" id="dial-type-group">
-      <label class="flex-1 flex items-center justify-center gap-2 min-h-12 border-2 border-base-300 rounded-lg cursor-pointer p-2 has-[:checked]:border-primary has-[:checked]:bg-primary/10">
+    <label class="label"><span class="label-text">Display Format</span></label>
+    <select
+      name="display_format"
+      id="display-format"
+      class="select select-bordered w-full"
+      onchange="updateRingFields()"
+    >
+      <option value="decimal" {% if not grinder or grinder.display_format == 'decimal' %}selected{% endif %}>Decimal (e.g. 15.5)</option>
+      <option value="x.y" {% if grinder and grinder.display_format == 'x.y' %}selected{% endif %}>X.Y (e.g. 3.2)</option>
+      <option value="x.y.z" {% if grinder and grinder.display_format == 'x.y.z' %}selected{% endif %}>X.Y.Z (e.g. 2.3.5)</option>
+    </select>
+  </div>
+
+  {# Decimal format — single ring #}
+  <div id="ring-decimal" class="ring-section">
+    <div class="flex gap-2 mb-4">
+      <div class="form-control flex-1">
+        <label class="label"><span class="label-text">Min</span></label>
         <input
-          type="radio"
-          name="dial_type"
-          value="stepless"
-          class="radio radio-primary"
-          {% if not grinder or grinder.dial_type == 'stepless' %}checked{% endif %}
-          onchange="updateDialFields()"
+          type="number"
+          name="ring_min"
+          class="input input-bordered w-full"
+          step="any"
+          placeholder="e.g. 0"
+          value="{{ grinder.ring_sizes[0][0] if grinder and grinder.ring_sizes else '' }}"
         >
-        Stepless
-      </label>
-      <label class="flex-1 flex items-center justify-center gap-2 min-h-12 border-2 border-base-300 rounded-lg cursor-pointer p-2 has-[:checked]:border-primary has-[:checked]:bg-primary/10">
+      </div>
+      <div class="form-control flex-1">
+        <label class="label"><span class="label-text">Max</span></label>
         <input
-          type="radio"
-          name="dial_type"
-          value="stepped"
-          class="radio radio-primary"
-          {% if grinder and grinder.dial_type == 'stepped' %}checked{% endif %}
-          onchange="updateDialFields()"
+          type="number"
+          name="ring_max"
+          class="input input-bordered w-full"
+          step="any"
+          placeholder="e.g. 40"
+          value="{{ grinder.ring_sizes[0][1] if grinder and grinder.ring_sizes else '' }}"
         >
-        Stepped
-      </label>
+      </div>
+      <div class="form-control flex-1">
+        <label class="label"><span class="label-text">Step</span></label>
+        <input
+          type="number"
+          name="ring_step"
+          class="input input-bordered w-full"
+          step="any"
+          placeholder="empty = continuous"
+          value="{{ grinder.ring_sizes[0][2] if grinder and grinder.ring_sizes and grinder.ring_sizes[0][2] is not none else '' }}"
+        >
+      </div>
     </div>
   </div>
 
-  <div id="stepped-fields" style="display:{% if grinder and grinder.dial_type == 'stepped' %}block{% else %}none{% endif %};">
-    <div class="form-control mb-4">
-      <label class="label"><span class="label-text">Step Size</span></label>
-      <input
-        type="number"
-        id="step-size"
-        name="step_size"
-        class="input input-bordered w-full"
-        step="any"
-        placeholder="e.g. 0.5"
-        value="{{ grinder.step_size if grinder and grinder.step_size is not none else '' }}"
-      >
+  {# X.Y format — two rings #}
+  <div id="ring-xy" class="ring-section" style="display:none;">
+    {% for ring_idx in [0, 1] %}
+    <div class="mb-3">
+      <div class="text-sm font-medium mb-1">Ring {{ ring_idx + 1 }}</div>
+      <div class="flex gap-2">
+        <div class="form-control flex-1">
+          <label class="label"><span class="label-text">Min</span></label>
+          <input
+            type="number"
+            name="ring_{{ ring_idx }}_min"
+            class="input input-bordered w-full"
+            step="any"
+            placeholder="0"
+            value="{{ grinder.ring_sizes[ring_idx][0] if grinder and grinder.ring_sizes and grinder.ring_sizes|length > ring_idx else '' }}"
+          >
+        </div>
+        <div class="form-control flex-1">
+          <label class="label"><span class="label-text">Max</span></label>
+          <input
+            type="number"
+            name="ring_{{ ring_idx }}_max"
+            class="input input-bordered w-full"
+            step="any"
+            placeholder="10"
+            value="{{ grinder.ring_sizes[ring_idx][1] if grinder and grinder.ring_sizes and grinder.ring_sizes|length > ring_idx else '' }}"
+          >
+        </div>
+        <div class="form-control flex-1">
+          <label class="label"><span class="label-text">Step</span></label>
+          <input
+            type="number"
+            name="ring_{{ ring_idx }}_step"
+            class="input input-bordered w-full"
+            step="any"
+            placeholder="1"
+            value="{{ grinder.ring_sizes[ring_idx][2] if grinder and grinder.ring_sizes and grinder.ring_sizes|length > ring_idx and grinder.ring_sizes[ring_idx][2] is not none else '' }}"
+          >
+        </div>
+      </div>
     </div>
+    {% endfor %}
   </div>
 
-  <div class="flex gap-2 mb-4">
-    <div class="form-control flex-1">
-      <label class="label"><span class="label-text">Min Setting</span></label>
-      <input
-        type="number"
-        id="min-value"
-        name="min_value"
-        class="input input-bordered w-full"
-        step="any"
-        placeholder="e.g. 0"
-        value="{{ grinder.min_value if grinder and grinder.min_value is not none else '' }}"
-      >
+  {# X.Y.Z format — three rings #}
+  <div id="ring-xyz" class="ring-section" style="display:none;">
+    {% for ring_idx in [0, 1, 2] %}
+    <div class="mb-3">
+      <div class="text-sm font-medium mb-1">Ring {{ ring_idx + 1 }}</div>
+      <div class="flex gap-2">
+        <div class="form-control flex-1">
+          <label class="label"><span class="label-text">Min</span></label>
+          <input
+            type="number"
+            name="ring_{{ ring_idx }}_min"
+            class="input input-bordered w-full"
+            step="any"
+            placeholder="0"
+            value="{{ grinder.ring_sizes[ring_idx][0] if grinder and grinder.ring_sizes and grinder.ring_sizes|length > ring_idx else '' }}"
+          >
+        </div>
+        <div class="form-control flex-1">
+          <label class="label"><span class="label-text">Max</span></label>
+          <input
+            type="number"
+            name="ring_{{ ring_idx }}_max"
+            class="input input-bordered w-full"
+            step="any"
+            placeholder="10"
+            value="{{ grinder.ring_sizes[ring_idx][1] if grinder and grinder.ring_sizes and grinder.ring_sizes|length > ring_idx else '' }}"
+          >
+        </div>
+        <div class="form-control flex-1">
+          <label class="label"><span class="label-text">Step</span></label>
+          <input
+            type="number"
+            name="ring_{{ ring_idx }}_step"
+            class="input input-bordered w-full"
+            step="any"
+            placeholder="1"
+            value="{{ grinder.ring_sizes[ring_idx][2] if grinder and grinder.ring_sizes and grinder.ring_sizes|length > ring_idx and grinder.ring_sizes[ring_idx][2] is not none else '' }}"
+          >
+        </div>
+      </div>
     </div>
-    <div class="form-control flex-1">
-      <label class="label"><span class="label-text">Max Setting</span></label>
-      <input
-        type="number"
-        id="max-value"
-        name="max_value"
-        class="input input-bordered w-full"
-        step="any"
-        placeholder="e.g. 40"
-        value="{{ grinder.max_value if grinder and grinder.max_value is not none else '' }}"
-      >
-    </div>
+    {% endfor %}
   </div>
 
   <button type="submit" class="btn btn-primary w-full min-h-12">
@@ -104,8 +175,17 @@
 </form>
 
 <script>
-  function updateDialFields() {
-    var stepped = document.querySelector('input[name="dial_type"][value="stepped"]').checked;
-    document.getElementById('stepped-fields').style.display = stepped ? 'block' : 'none';
+  function updateRingFields() {
+    var fmt = document.getElementById('display-format').value;
+    document.querySelectorAll('.ring-section').forEach(function(el) { el.style.display = 'none'; });
+    if (fmt === 'x.y') {
+      document.getElementById('ring-xy').style.display = 'block';
+    } else if (fmt === 'x.y.z') {
+      document.getElementById('ring-xyz').style.display = 'block';
+    } else {
+      document.getElementById('ring-decimal').style.display = 'block';
+    }
   }
+  // Initialize on load
+  updateRingFields();
 </script>

--- a/app/templates/equipment/_grinder_form.html
+++ b/app/templates/equipment/_grinder_form.html
@@ -43,7 +43,7 @@
   </div>
 
   {# Decimal format — single ring #}
-  <div id="ring-decimal" class="ring-section">
+  <div id="ring-decimal" class="ring-section" {% if grinder and grinder.display_format != 'decimal' %}style="display:none;"{% endif %}>
     <div class="flex gap-2 mb-4">
       <div class="form-control flex-1">
         <label class="label"><span class="label-text">Min</span></label>
@@ -82,7 +82,7 @@
   </div>
 
   {# X.Y format — two rings #}
-  <div id="ring-xy" class="ring-section" style="display:none;">
+  <div id="ring-xy" class="ring-section" {% if not grinder or grinder.display_format != 'x.y' %}style="display:none;"{% endif %}>
     {% for ring_idx in [0, 1] %}
     <div class="mb-3">
       <div class="text-sm font-medium mb-1">Ring {{ ring_idx + 1 }}</div>
@@ -126,7 +126,7 @@
   </div>
 
   {# X.Y.Z format — three rings #}
-  <div id="ring-xyz" class="ring-section" style="display:none;">
+  <div id="ring-xyz" class="ring-section" {% if not grinder or grinder.display_format != 'x.y.z' %}style="display:none;"{% endif %}>
     {% for ring_idx in [0, 1, 2] %}
     <div class="mb-3">
       <div class="text-sm font-medium mb-1">Ring {{ ring_idx + 1 }}</div>

--- a/app/templates/equipment/_setup_wizard.html
+++ b/app/templates/equipment/_setup_wizard.html
@@ -83,13 +83,21 @@
             >
             <div class="wizard-option-name">{{ grinder.name }}</div>
             <div class="wizard-option-meta">
-              {% if grinder.dial_type == "stepped" %}
-                Stepped{% if grinder.step_size is not none %} · step {{ grinder.step_size }}{% endif %}
-              {% else %}
-                Stepless
-              {% endif %}
-              {% if grinder.min_value is not none and grinder.max_value is not none %}
-                · {{ grinder.min_value }}–{{ grinder.max_value }}
+              {% if grinder.ring_sizes %}
+                {% if grinder.display_format == 'x.y' or grinder.display_format == 'x.y.z' %}
+                  {{ grinder.display_format }} · {{ grinder.ring_sizes|length }} rings
+                  {% set bounds = grinder.linear_bounds() %}
+                  {% if bounds %}
+                    · {{ grinder.to_display(bounds[0]) }}–{{ grinder.to_display(bounds[1]) }}
+                  {% endif %}
+                {% else %}
+                  {% if grinder.ring_sizes[0][2] is not none %}
+                    Stepped · step {{ grinder.ring_sizes[0][2] }}
+                  {% else %}
+                    Stepless
+                  {% endif %}
+                  · {{ grinder.ring_sizes[0][0] }}–{{ grinder.ring_sizes[0][1] }}
+                {% endif %}
               {% endif %}
             </div>
           </label>

--- a/app/templates/history/_shot_modal.html
+++ b/app/templates/history/_shot_modal.html
@@ -26,7 +26,7 @@
     <div class="recipe-params text-sm">
       <div class="recipe-param">
         <span class="recipe-label">Grind</span>
-        <span class="recipe-value text-lg">{{ shot.grind_setting }}</span>
+        <span class="recipe-value text-lg">{{ shot.grind_display if shot.grind_display is defined and shot.grind_display else shot.grind_setting }}</span>
       </div>
       {% if shot.temperature is not none %}
       <div class="recipe-param">

--- a/app/templates/history/_shot_row.html
+++ b/app/templates/history/_shot_row.html
@@ -16,7 +16,7 @@
       <span class="text-lg font-bold {% if shot.is_failed %}text-error{% endif %}">
         {{ shot.taste }}/10
       </span>
-      <span class="text-sm text-base-content/70">Grind {{ shot.grind_setting }}</span>
+      <span class="text-sm text-base-content/70">Grind {{ shot.grind_display if shot.grind_display is defined and shot.grind_display else shot.grind_setting }}</span>
       <span class="text-sm text-base-content/40 truncate">{{ shot.bean_name }}</span>
     </div>
   </div>

--- a/migrations/versions/8d6331efcb5c_grinder_ring_sizes_display_format.py
+++ b/migrations/versions/8d6331efcb5c_grinder_ring_sizes_display_format.py
@@ -1,0 +1,156 @@
+"""grinder_ring_sizes_display_format
+
+Revision ID: 8d6331efcb5c
+Revises: 9052fc4244a4
+Create Date: 2026-02-28 11:13:31.322629
+
+"""
+
+import json
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect, text
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8d6331efcb5c"
+down_revision: Union[str, Sequence[str], None] = "9052fc4244a4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _get_column_names(inspector, table_name):
+    """Return set of column names for a table, or empty set if table doesn't exist."""
+    tables = inspector.get_table_names()
+    if table_name not in tables:
+        return set()
+    return {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    """Add display_format + ring_sizes_json, populate from legacy data, drop legacy columns."""
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    grinders_cols = _get_column_names(inspector, "grinders")
+
+    # 1. Add new columns if they don't already exist
+    if "display_format" not in grinders_cols:
+        with op.batch_alter_table("grinders", schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column("display_format", sa.String(), nullable=False, server_default="decimal")
+            )
+        op.execute(text("UPDATE grinders SET display_format = 'decimal' WHERE display_format IS NULL"))
+
+    if "ring_sizes_json" not in grinders_cols:
+        with op.batch_alter_table("grinders", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("ring_sizes_json", sa.Text(), nullable=True))
+
+    # 2. Populate ring_sizes_json from legacy columns (only if legacy columns still exist)
+    # Re-inspect after potential column additions
+    inspector = inspect(conn)
+    grinders_cols = _get_column_names(inspector, "grinders")
+
+    if "min_value" in grinders_cols and "max_value" in grinders_cols:
+        # Read all existing grinders and compute ring_sizes from legacy data
+        rows = conn.execute(
+            text("SELECT id, dial_type, step_size, min_value, max_value FROM grinders")
+        ).fetchall()
+        for row in rows:
+            grinder_id = row[0]
+            dial_type = row[1]
+            step_size = row[2]
+            min_val = row[3]
+            max_val = row[4]
+
+            ring_min = min_val if min_val is not None else 0.0
+            ring_max = max_val if max_val is not None else 50.0
+            ring_step = step_size if dial_type == "stepped" else None
+            ring_sizes = json.dumps([[ring_min, ring_max, ring_step]])
+
+            conn.execute(
+                text("UPDATE grinders SET ring_sizes_json = :rs WHERE id = :gid"),
+                {"rs": ring_sizes, "gid": grinder_id},
+            )
+
+    # 3. Set display_format = "decimal" for any grinders that don't have it set
+    conn.execute(
+        text("UPDATE grinders SET display_format = 'decimal' WHERE display_format IS NULL")
+    )
+
+    # 4. Drop legacy columns
+    legacy_cols = ["dial_type", "step_size", "min_value", "max_value"]
+    cols_to_drop = [c for c in legacy_cols if c in grinders_cols]
+    if cols_to_drop:
+        with op.batch_alter_table("grinders", schema=None) as batch_op:
+            for col in cols_to_drop:
+                batch_op.drop_column(col)
+
+
+def downgrade() -> None:
+    """Re-add legacy columns, populate from ring_sizes_json, drop new columns."""
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    grinders_cols = _get_column_names(inspector, "grinders")
+
+    # 1. Re-add legacy columns
+    if "dial_type" not in grinders_cols:
+        with op.batch_alter_table("grinders", schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column("dial_type", sa.String(), nullable=False, server_default="stepless")
+            )
+
+    if "step_size" not in grinders_cols:
+        with op.batch_alter_table("grinders", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("step_size", sa.Float(), nullable=True))
+
+    if "min_value" not in grinders_cols:
+        with op.batch_alter_table("grinders", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("min_value", sa.Float(), nullable=True))
+
+    if "max_value" not in grinders_cols:
+        with op.batch_alter_table("grinders", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("max_value", sa.Float(), nullable=True))
+
+    # 2. Populate legacy columns from ring_sizes_json (if it exists)
+    inspector = inspect(conn)
+    grinders_cols = _get_column_names(inspector, "grinders")
+
+    if "ring_sizes_json" in grinders_cols:
+        rows = conn.execute(
+            text("SELECT id, ring_sizes_json FROM grinders")
+        ).fetchall()
+        for row in rows:
+            grinder_id = row[0]
+            ring_sizes_json = row[1]
+            if ring_sizes_json:
+                rings = json.loads(ring_sizes_json)
+                if rings and len(rings) > 0:
+                    ring = rings[0]  # Use first ring for legacy columns
+                    min_val = ring[0]
+                    max_val = ring[1]
+                    step = ring[2] if len(ring) > 2 else None
+                    dial_type = "stepped" if step is not None else "stepless"
+
+                    conn.execute(
+                        text(
+                            "UPDATE grinders SET dial_type = :dt, step_size = :ss, "
+                            "min_value = :mi, max_value = :ma WHERE id = :gid"
+                        ),
+                        {
+                            "dt": dial_type,
+                            "ss": step,
+                            "mi": min_val,
+                            "ma": max_val,
+                            "gid": grinder_id,
+                        },
+                    )
+
+    # 3. Drop new columns
+    new_cols = ["display_format", "ring_sizes_json"]
+    cols_to_drop = [c for c in new_cols if c in grinders_cols]
+    if cols_to_drop:
+        with op.batch_alter_table("grinders", schema=None) as batch_op:
+            for col in cols_to_drop:
+                batch_op.drop_column(col)

--- a/tests/test_brew.py
+++ b/tests/test_brew.py
@@ -740,6 +740,70 @@ def test_record_manual_brew_end_to_end(active_client, sample_bean, db_session):
     assert m.taste == 8.0
 
 
+def test_record_manual_brew_multi_ring_grinder(active_client, sample_bean, db_session):
+    """POST /brew/record with x.y.z grind notation converts to linear value and saves."""
+    from unittest.mock import MagicMock
+
+    from app.models.brew_method import BrewMethod
+    from app.models.brew_setup import BrewSetup
+    from app.models.equipment import Grinder
+
+    mock_optimizer = MagicMock()
+    mock_optimizer.recommend = AsyncMock()
+    app.state.optimizer = mock_optimizer
+
+    # Create a multi-ring grinder and brew setup
+    grinder = Grinder(
+        name="X-Ultra",
+        display_format="x.y.z",
+        ring_sizes=[[0, 4, 1], [0, 5, 1], [0, 10, 1]],
+    )
+    db_session.add(grinder)
+    # Get or create pour-over brew method
+    brew_method = db_session.query(BrewMethod).filter_by(name="pour-over").first()
+    if not brew_method:
+        brew_method = BrewMethod(name="pour-over")
+        db_session.add(brew_method)
+    db_session.flush()
+    setup = BrewSetup(name="Pour Over Setup", brew_method_id=brew_method.id, grinder_id=grinder.id)
+    db_session.add(setup)
+    db_session.commit()
+    db_session.refresh(setup)
+
+    # Set active setup cookie
+    active_client.cookies.set("active_setup_id", str(setup.id))
+
+    rec_id = str(uuid.uuid4())
+    payload = {
+        "recommendation_id": rec_id,
+        "is_manual": "true",
+        "method": "pour-over",
+        "brew_setup_id": str(setup.id),
+        "grind_setting": "2.2.0",  # x.y.z notation → linear = 2*(6*11) + 2*11 + 0 = 154
+        "temperature": "92.0",
+        "dose_in": "15.0",
+        "brew_volume": "255.0",
+        "bloom_weight": "52.0",
+        "taste": "8.5",
+    }
+    response = active_client.post("/brew/record", data=payload, follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/brew"
+
+    db_session.expire_all()
+    m = db_session.query(Measurement).filter(Measurement.recommendation_id == rec_id).first()
+    assert m is not None
+    assert m.is_manual is True
+    assert m.grind_setting == 154.0  # Linear value from "2.2.0"
+    assert m.taste == 8.5
+
+    # Verify optimizer.add_measurement was called with the linear value
+    mock_optimizer.add_measurement.assert_called_once()
+    call_args = mock_optimizer.add_measurement.call_args
+    measurement_data = call_args[1]["measurement"] if "measurement" in call_args[1] else call_args[0][1]
+    assert measurement_data["grind_setting"] == 154.0
+
+
 def test_manual_page_shows_bean_bounds(active_client, sample_bean):
     """GET /brew/manual -> shows default parameter bounds in form."""
     response = active_client.get("/brew/manual")

--- a/tests/test_equipment.py
+++ b/tests/test_equipment.py
@@ -27,10 +27,8 @@ def sample_grinder(db_session):
     """Create a sample stepped grinder."""
     grinder = Grinder(
         name="Comandante C40",
-        dial_type="stepped",
-        step_size=0.5,
-        min_value=1.0,
-        max_value=40.0,
+        display_format="decimal",
+        ring_sizes=[[1, 40, 1]],
     )
     db_session.add(grinder)
     db_session.commit()
@@ -100,15 +98,15 @@ def test_equipment_page_shows_counts(
 
 
 def test_create_grinder_stepped(client, db_session):
-    """POST /equipment/grinders with stepped config creates grinder in DB."""
+    """POST /equipment/grinders with stepped (decimal) config creates grinder in DB."""
     response = client.post(
         "/equipment/grinders",
         data={
             "name": "Comandante C40",
-            "dial_type": "stepped",
-            "step_size": "1",
-            "min_value": "1",
-            "max_value": "40",
+            "display_format": "decimal",
+            "ring_min": "1",
+            "ring_max": "40",
+            "ring_step": "1",
         },
         follow_redirects=False,
     )
@@ -116,21 +114,20 @@ def test_create_grinder_stepped(client, db_session):
 
     grinder = db_session.query(Grinder).filter(Grinder.name == "Comandante C40").first()
     assert grinder is not None
-    assert grinder.dial_type == "stepped"
-    assert grinder.step_size == 1.0
-    assert grinder.min_value == 1.0
-    assert grinder.max_value == 40.0
+    assert grinder.display_format == "decimal"
+    assert grinder.ring_sizes == [(1.0, 40.0, 1.0)]
 
 
 def test_create_grinder_stepless(client, db_session):
-    """POST /equipment/grinders with stepless config creates grinder."""
+    """POST /equipment/grinders with stepless (continuous) config creates grinder."""
     response = client.post(
         "/equipment/grinders",
         data={
             "name": "Lagom P64",
-            "dial_type": "stepless",
-            "min_value": "0",
-            "max_value": "100",
+            "display_format": "decimal",
+            "ring_min": "0",
+            "ring_max": "100",
+            "ring_step": "",
         },
         follow_redirects=False,
     )
@@ -138,20 +135,20 @@ def test_create_grinder_stepless(client, db_session):
 
     grinder = db_session.query(Grinder).filter(Grinder.name == "Lagom P64").first()
     assert grinder is not None
-    assert grinder.dial_type == "stepless"
-    assert grinder.step_size is None
+    assert grinder.display_format == "decimal"
+    assert grinder.ring_sizes == [(0.0, 100.0, None)]
 
 
 def test_edit_grinder(client, sample_grinder, db_session):
-    """POST /equipment/grinders/{id} updates name and dial config."""
+    """POST /equipment/grinders/{id} updates name and ring config."""
     response = client.post(
         f"/equipment/grinders/{sample_grinder.id}",
         data={
             "name": "Comandante C40 MK4",
-            "dial_type": "stepped",
-            "step_size": "0.5",
-            "min_value": "0",
-            "max_value": "50",
+            "display_format": "decimal",
+            "ring_min": "0",
+            "ring_max": "50",
+            "ring_step": "0.5",
         },
         follow_redirects=False,
     )
@@ -160,7 +157,7 @@ def test_edit_grinder(client, sample_grinder, db_session):
     db_session.expire_all()
     updated = db_session.query(Grinder).filter(Grinder.id == sample_grinder.id).first()
     assert updated.name == "Comandante C40 MK4"
-    assert updated.max_value == 50.0
+    assert updated.ring_sizes == [(0.0, 50.0, 0.5)]
 
 
 def test_edit_grinder_form(client, sample_grinder):

--- a/tests/test_grinder_bounds.py
+++ b/tests/test_grinder_bounds.py
@@ -28,13 +28,28 @@ def test_grind_setting_clipped_to_grinder_range():
     assert grind_param.bounds.lower >= 0.0
 
 
-def test_grind_setting_clipped_preserves_method_lower_bound():
-    """If grinder range wider than method default, use method default."""
+def test_grind_setting_uses_percentage_range_with_grinder():
+    """With a grinder, grind bounds come from METHOD_GRIND_PERCENTAGES, not registry defaults."""
+    # Grinder 0-100, espresso percentages are (0.15, 0.40) → (15.0, 40.0)
     grinder = Grinder(name="Wide", display_format="decimal", ring_sizes=[[0, 100, None]])
     params = build_parameters_for_setup("espresso", grinder=grinder)
     grind_param = next(p for p in params if p.name == "grind_setting")
-    assert grind_param.bounds.lower == 15.0  # espresso default
-    assert grind_param.bounds.upper == 25.0  # espresso default
+    assert grind_param.bounds.lower == 15.0  # 0.15 * 100
+    assert grind_param.bounds.upper == 40.0  # 0.40 * 100
+
+
+def test_multi_ring_grinder_pour_over_range():
+    """Multi-ring grinder should get pour-over range from percentages, not registry defaults."""
+    # X-Ultra: 330 total steps (0-329), pour-over percentages (0.40, 0.70)
+    grinder = Grinder(
+        name="X-Ultra", display_format="x.y.z",
+        ring_sizes=[[0, 4, 1], [0, 5, 1], [0, 10, 1]],
+    )
+    params = build_parameters_for_setup("pour-over", grinder=grinder)
+    grind_param = next(p for p in params if p.name == "grind_setting")
+    # 0.40 * 329 ≈ 131.6, 0.70 * 329 ≈ 230.3
+    assert grind_param.bounds.lower > 100  # NOT 15.0 from registry
+    assert grind_param.bounds.upper > 200  # NOT 40.0 from registry
 
 
 def test_grind_setting_with_override_and_grinder():
@@ -112,12 +127,14 @@ def test_fingerprint_same_when_same_grinder():
     assert fp_1 == fp_2
 
 
-def test_resolve_bounds_clips_grind_to_grinder():
-    """_resolve_bounds should clip grind_setting to grinder's physical range."""
+def test_resolve_bounds_uses_suggested_range_with_grinder():
+    """_resolve_bounds should use percentage-based range with grinder, clipped to physical limits."""
     grinder = Grinder(name="Narrow", display_format="decimal", ring_sizes=[[0, 18, 1]])
     bounds = _resolve_bounds(None, "espresso", grinder=grinder)
-    # Espresso default grind is (15, 25), grinder max is 18 -> (15, 18)
-    assert bounds["grind_setting"] == (15.0, 18.0)
+    # Espresso percentages (0.15, 0.40) on range 0-18 → (2.7, 7.2)
+    lo, hi = bounds["grind_setting"]
+    assert lo < 15.0  # NOT registry default
+    assert hi <= 18.0  # Clipped to grinder max
 
 
 def test_resolve_bounds_no_grinder_preserves_defaults():

--- a/tests/test_grinder_bounds.py
+++ b/tests/test_grinder_bounds.py
@@ -1,0 +1,126 @@
+"""Tests for grinder bounds enforcement (Task 4), step snapping (Task 5), and fingerprint (Task 9).
+
+Covers:
+  - Grind setting bounds clipped to grinder's physical range
+  - Bean overrides + grinder constraint interaction
+  - snap_grind_to_step for continuous, stepped, half-step, and multi-ring grinders
+  - Clamping to grinder bounds
+  - No-grinder passthrough
+  - Campaign fingerprint changes when grinder bounds change
+"""
+
+from app.models.equipment import Grinder
+from app.services.optimizer import _bounds_fingerprint, _resolve_bounds, snap_grind_to_step
+from app.services.parameter_registry import build_parameters_for_setup
+
+
+# ===========================================================================
+# Task 4: Bounds Enforcement in Optimizer
+# ===========================================================================
+
+
+def test_grind_setting_clipped_to_grinder_range():
+    """If grinder max is 18, grind_setting bounds should not exceed 18."""
+    grinder = Grinder(name="Small", display_format="decimal", ring_sizes=[[0, 18, 1]])
+    params = build_parameters_for_setup("espresso", grinder=grinder)
+    grind_param = next(p for p in params if p.name == "grind_setting")
+    assert grind_param.bounds.upper <= 18.0
+    assert grind_param.bounds.lower >= 0.0
+
+
+def test_grind_setting_clipped_preserves_method_lower_bound():
+    """If grinder range wider than method default, use method default."""
+    grinder = Grinder(name="Wide", display_format="decimal", ring_sizes=[[0, 100, None]])
+    params = build_parameters_for_setup("espresso", grinder=grinder)
+    grind_param = next(p for p in params if p.name == "grind_setting")
+    assert grind_param.bounds.lower == 15.0  # espresso default
+    assert grind_param.bounds.upper == 25.0  # espresso default
+
+
+def test_grind_setting_with_override_and_grinder():
+    """Bean override + grinder constraint: grinder is hard ceiling."""
+    grinder = Grinder(name="G", display_format="decimal", ring_sizes=[[0, 20, 0.5]])
+    overrides = {"grind_setting": {"min": 10.0, "max": 25.0}}
+    params = build_parameters_for_setup("espresso", grinder=grinder, overrides=overrides)
+    grind_param = next(p for p in params if p.name == "grind_setting")
+    assert grind_param.bounds.lower == 10.0
+    assert grind_param.bounds.upper == 20.0  # Clipped from 25 to grinder max
+
+
+def test_no_grinder_uses_defaults():
+    """Without a grinder, default bounds are used."""
+    params = build_parameters_for_setup("espresso")
+    grind_param = next(p for p in params if p.name == "grind_setting")
+    assert grind_param.bounds.lower == 15.0
+    assert grind_param.bounds.upper == 25.0
+
+
+# ===========================================================================
+# Task 5: Post-Recommendation Step Snapping
+# ===========================================================================
+
+
+class TestSnapGrindToStep:
+    def test_continuous_no_snap(self):
+        grinder = Grinder(name="Niche", display_format="decimal", ring_sizes=[[0, 50, None]])
+        assert snap_grind_to_step(25.3, grinder) == 25.3
+
+    def test_stepped_snaps_to_nearest(self):
+        grinder = Grinder(name="C40", display_format="decimal", ring_sizes=[[0, 40, 1]])
+        assert snap_grind_to_step(25.3, grinder) == 25.0
+        assert snap_grind_to_step(25.7, grinder) == 26.0
+
+    def test_half_step_snaps(self):
+        grinder = Grinder(name="G1", display_format="decimal", ring_sizes=[[0, 40, 0.5]])
+        assert snap_grind_to_step(25.3, grinder) == 25.5
+        assert snap_grind_to_step(25.1, grinder) == 25.0
+
+    def test_multi_ring_snaps_to_integer(self):
+        grinder = Grinder(name="Sette", display_format="x.y", ring_sizes=[[0, 30, 1], [0, 9, 1]])
+        assert snap_grind_to_step(155.4, grinder) == 155.0
+        assert snap_grind_to_step(155.6, grinder) == 156.0
+
+    def test_clamps_to_bounds(self):
+        grinder = Grinder(name="C40", display_format="decimal", ring_sizes=[[0, 40, 1]])
+        assert snap_grind_to_step(-1.0, grinder) == 0.0
+        assert snap_grind_to_step(41.0, grinder) == 40.0
+
+    def test_no_grinder_returns_value(self):
+        assert snap_grind_to_step(25.3, None) == 25.3
+
+
+# ===========================================================================
+# Task 9: Campaign Fingerprint Includes Grinder Bounds
+# ===========================================================================
+
+
+def test_fingerprint_changes_when_grinder_bounds_change():
+    """Different grinder ranges should produce different fingerprints."""
+    grinder_a = Grinder(name="A", display_format="decimal", ring_sizes=[[0, 40, 1]])
+    grinder_b = Grinder(name="B", display_format="decimal", ring_sizes=[[0, 18, 1]])
+
+    fp_a = _bounds_fingerprint(_resolve_bounds(None, "espresso", grinder=grinder_a))
+    fp_b = _bounds_fingerprint(_resolve_bounds(None, "espresso", grinder=grinder_b))
+    assert fp_a != fp_b, "Different grinder ranges should produce different fingerprints"
+
+
+def test_fingerprint_same_when_same_grinder():
+    """Same grinder should produce identical fingerprints."""
+    grinder = Grinder(name="A", display_format="decimal", ring_sizes=[[0, 40, 1]])
+    fp_1 = _bounds_fingerprint(_resolve_bounds(None, "espresso", grinder=grinder))
+    fp_2 = _bounds_fingerprint(_resolve_bounds(None, "espresso", grinder=grinder))
+    assert fp_1 == fp_2
+
+
+def test_resolve_bounds_clips_grind_to_grinder():
+    """_resolve_bounds should clip grind_setting to grinder's physical range."""
+    grinder = Grinder(name="Narrow", display_format="decimal", ring_sizes=[[0, 18, 1]])
+    bounds = _resolve_bounds(None, "espresso", grinder=grinder)
+    # Espresso default grind is (15, 25), grinder max is 18 -> (15, 18)
+    assert bounds["grind_setting"] == (15.0, 18.0)
+
+
+def test_resolve_bounds_no_grinder_preserves_defaults():
+    """Without a grinder, _resolve_bounds should return unclipped defaults."""
+    bounds = _resolve_bounds(None, "espresso")
+    assert bounds["grind_setting"] == (15.0, 25.0)

--- a/tests/test_grinder_helpers.py
+++ b/tests/test_grinder_helpers.py
@@ -1,0 +1,224 @@
+"""Tests for Grinder helper methods: linear_bounds, finest_step, to_display, from_display."""
+
+import pytest
+
+from app.models.equipment import Grinder
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def continuous_grinder():
+    """Single-ring continuous grinder (0-50, stepless)."""
+    return Grinder(
+        name="Niche Zero",
+        display_format="decimal",
+        ring_sizes=[(0, 50, None)],
+    )
+
+
+@pytest.fixture()
+def stepped_grinder():
+    """Single-ring stepped grinder (0-40, step=1)."""
+    return Grinder(
+        name="Eureka Mignon",
+        display_format="decimal",
+        ring_sizes=[(0, 40, 1)],
+    )
+
+
+@pytest.fixture()
+def half_step_grinder():
+    """Single-ring stepped grinder with half-steps (0-20, step=0.5)."""
+    return Grinder(
+        name="Half-Step Grinder",
+        display_format="decimal",
+        ring_sizes=[(0, 20, 0.5)],
+    )
+
+
+@pytest.fixture()
+def two_ring_grinder():
+    """Two-ring grinder X.Y: X in 0-30, Y in 0-9."""
+    return Grinder(
+        name="Lagom P64",
+        display_format="x.y",
+        ring_sizes=[(0, 30, 1), (0, 9, 1)],
+    )
+
+
+@pytest.fixture()
+def three_ring_grinder():
+    """Three-ring grinder X.Y.Z: X in 0-4, Y in 0-5, Z in 0-10."""
+    return Grinder(
+        name="Commandante C40",
+        display_format="x.y.z",
+        ring_sizes=[(0, 4, 1), (0, 5, 1), (0, 10, 1)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestLinearBounds
+# ---------------------------------------------------------------------------
+
+class TestLinearBounds:
+    """Tests for Grinder.linear_bounds()."""
+
+    def test_single_ring_continuous(self, continuous_grinder):
+        assert continuous_grinder.linear_bounds() == (0.0, 50.0)
+
+    def test_single_ring_stepped(self, stepped_grinder):
+        assert stepped_grinder.linear_bounds() == (0.0, 40.0)
+
+    def test_two_rings(self, two_ring_grinder):
+        # 31 * 10 = 310 positions, linear range 0-309
+        assert two_ring_grinder.linear_bounds() == (0.0, 309.0)
+
+    def test_three_rings(self, three_ring_grinder):
+        # 5 * 6 * 11 = 330 positions, linear range 0-329
+        assert three_ring_grinder.linear_bounds() == (0.0, 329.0)
+
+    def test_none_ring_sizes(self):
+        g = Grinder(name="Unknown")
+        assert g.linear_bounds() is None
+
+
+# ---------------------------------------------------------------------------
+# TestFinestStep
+# ---------------------------------------------------------------------------
+
+class TestFinestStep:
+    """Tests for Grinder.finest_step()."""
+
+    def test_continuous_returns_none(self, continuous_grinder):
+        assert continuous_grinder.finest_step() is None
+
+    def test_single_stepped(self, stepped_grinder):
+        assert stepped_grinder.finest_step() == 1.0
+
+    def test_multi_ring(self, three_ring_grinder):
+        assert three_ring_grinder.finest_step() == 1.0
+
+    def test_half_step_decimal(self, half_step_grinder):
+        assert half_step_grinder.finest_step() == 0.5
+
+
+# ---------------------------------------------------------------------------
+# TestToDisplay
+# ---------------------------------------------------------------------------
+
+class TestToDisplay:
+    """Tests for Grinder.to_display(value)."""
+
+    def test_decimal_continuous(self, continuous_grinder):
+        assert continuous_grinder.to_display(25.3) == "25.3"
+
+    def test_decimal_stepped_whole(self, stepped_grinder):
+        # Whole numbers should not show trailing .0
+        assert stepped_grinder.to_display(28.0) == "28"
+
+    def test_two_rings(self, two_ring_grinder):
+        # 15*10 + 5 = 155
+        assert two_ring_grinder.to_display(155.0) == "15.5"
+
+    def test_three_rings(self, three_ring_grinder):
+        # 2*66 + 3*11 + 7 = 132+33+7 = 172
+        assert three_ring_grinder.to_display(172.0) == "2.3.7"
+
+    def test_three_rings_zero(self, three_ring_grinder):
+        assert three_ring_grinder.to_display(0.0) == "0.0.0"
+
+    def test_three_rings_max(self, three_ring_grinder):
+        # 4*66 + 5*11 + 10 = 264+55+10 = 329
+        assert three_ring_grinder.to_display(329.0) == "4.5.10"
+
+
+# ---------------------------------------------------------------------------
+# TestFromDisplay
+# ---------------------------------------------------------------------------
+
+class TestFromDisplay:
+    """Tests for Grinder.from_display(text)."""
+
+    def test_decimal(self, continuous_grinder):
+        assert continuous_grinder.from_display("25.3") == 25.3
+
+    def test_decimal_stepped(self, stepped_grinder):
+        assert stepped_grinder.from_display("28") == 28.0
+
+    def test_two_rings(self, two_ring_grinder):
+        # 15*10 + 5 = 155
+        assert two_ring_grinder.from_display("15.5") == 155.0
+
+    def test_three_rings(self, three_ring_grinder):
+        # 2*66 + 3*11 + 7 = 172
+        assert three_ring_grinder.from_display("2.3.7") == 172.0
+
+    def test_roundtrip_two_rings(self, two_ring_grinder):
+        """Every valid linear value should round-trip through display notation."""
+        for linear in range(310):  # 0-309
+            displayed = two_ring_grinder.to_display(float(linear))
+            recovered = two_ring_grinder.from_display(displayed)
+            assert recovered == float(linear), (
+                f"Roundtrip failed for linear={linear}: "
+                f"to_display={displayed}, from_display={recovered}"
+            )
+
+    def test_roundtrip_three_rings(self, three_ring_grinder):
+        """Every valid linear value should round-trip through display notation."""
+        for linear in range(330):  # 0-329
+            displayed = three_ring_grinder.to_display(float(linear))
+            recovered = three_ring_grinder.from_display(displayed)
+            assert recovered == float(linear), (
+                f"Roundtrip failed for linear={linear}: "
+                f"to_display={displayed}, from_display={recovered}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestRingSizesProperty
+# ---------------------------------------------------------------------------
+
+class TestRingSizesProperty:
+    """Tests for the ring_sizes JSON property pattern."""
+
+    def test_set_via_constructor(self, two_ring_grinder):
+        assert two_ring_grinder.ring_sizes == [(0, 30, 1), (0, 9, 1)]
+
+    def test_set_via_property(self):
+        g = Grinder(name="Test")
+        g.ring_sizes = [(0, 50, None)]
+        assert g.ring_sizes == [(0, 50, None)]
+
+    def test_none_by_default(self):
+        g = Grinder(name="Test")
+        assert g.ring_sizes is None
+
+    def test_json_roundtrip(self):
+        """Setting ring_sizes stores JSON and retrieves the same structure."""
+        rings = [(0, 4, 1), (0, 5, 1), (0, 10, 1)]
+        g = Grinder(name="Test", ring_sizes=rings)
+        # Access the raw JSON column to verify serialization
+        import json
+        raw = json.loads(g.ring_sizes_json)
+        assert raw == [[0, 4, 1], [0, 5, 1], [0, 10, 1]]
+        # Property should convert back to tuples
+        assert g.ring_sizes == [(0, 4, 1), (0, 5, 1), (0, 10, 1)]
+
+
+# ---------------------------------------------------------------------------
+# TestDisplayFormat
+# ---------------------------------------------------------------------------
+
+class TestDisplayFormat:
+    """Tests for the display_format column."""
+
+    def test_default_display_format(self):
+        g = Grinder(name="Test")
+        assert g.display_format == "decimal"
+
+    def test_set_display_format(self):
+        g = Grinder(name="Test", display_format="x.y.z")
+        assert g.display_format == "x.y.z"

--- a/tests/test_grinder_integration.py
+++ b/tests/test_grinder_integration.py
@@ -1,0 +1,53 @@
+"""Integration test: grinder bounds enforcement through full recommendation flow."""
+
+import pytest
+
+from app.models.equipment import Grinder
+from app.services.optimizer import snap_grind_to_step
+from app.services.parameter_registry import build_parameters_for_setup
+
+
+class TestGrinderBoundsIntegration:
+    """Test that grinder bounds are enforced end-to-end."""
+
+    def test_build_params_clips_to_grinder(self):
+        """build_parameters_for_setup clips grind_setting to grinder range."""
+        grinder = Grinder(name="Small", display_format="decimal", ring_sizes=[[0, 18, 1]])
+        params = build_parameters_for_setup("espresso", grinder=grinder)
+        grind = next(p for p in params if p.name == "grind_setting")
+        # Espresso default is (15, 25), grinder max is 18 -> should clip to (15, 18)
+        assert grind.bounds.lower >= 0
+        assert grind.bounds.upper <= 18
+
+    def test_snap_respects_grinder_step(self):
+        """snap_grind_to_step snaps to valid grinder steps."""
+        grinder = Grinder(name="Stepped", display_format="decimal", ring_sizes=[[0, 40, 0.5]])
+        assert snap_grind_to_step(17.3, grinder) == 17.5
+        assert snap_grind_to_step(17.1, grinder) == 17.0
+
+    def test_multi_ring_display_roundtrip(self):
+        """Multi-ring grinder display format roundtrips correctly."""
+        grinder = Grinder(
+            name="X-Ultra", display_format="x.y.z",
+            ring_sizes=[[0, 4, 1], [0, 5, 1], [0, 10, 1]]
+        )
+        # to_display and from_display are inverses
+        for linear in range(330):
+            display = grinder.to_display(float(linear))
+            back = grinder.from_display(display)
+            assert back == float(linear), f"Roundtrip failed for {linear}: {display} -> {back}"
+
+    def test_grinder_bounds_with_bean_overrides(self):
+        """Grinder bounds are a hard ceiling even with wider bean overrides."""
+        grinder = Grinder(name="Narrow", display_format="decimal", ring_sizes=[[0, 20, 1]])
+        overrides = {"grind_setting": {"min": 5.0, "max": 30.0}}
+        params = build_parameters_for_setup("espresso", grinder=grinder, overrides=overrides)
+        grind = next(p for p in params if p.name == "grind_setting")
+        assert grind.bounds.upper <= 20.0  # Grinder caps it
+
+    def test_no_grinder_preserves_defaults(self):
+        """Without grinder, espresso defaults are preserved."""
+        params = build_parameters_for_setup("espresso")
+        grind = next(p for p in params if p.name == "grind_setting")
+        assert grind.bounds.lower == 15.0
+        assert grind.bounds.upper == 25.0


### PR DESCRIPTION
> [!Note]
> This is a proof of concept draft PR to discuss the direction. Beside some fine-grained instructions it is mostly written by Claude and I am not happy with some of the code changes / testing strategies it made. Before considering merging I would clean need to clean this up.
> Before doing so, I'd be interested in your view and if you are interested in merging this at some point in the first place (i.e. is the clean up worth the effort).

Grinder min/max now automatically constrains the BayBE search space, preventing recommendations outside the grinder's physical range (#4). Adds support for hierarchical grind scales (X.Y, X.Y.Z) used by grinders like the 1Zpresso X-Ultra and Sette 270 (#1).

Replaces dial_type/step_size/min_value/max_value with a unified ring_sizes model. Recommendations are snapped to valid dial positions for stepped grinders. Campaign fingerprinting detects grinder changes.

Closes #1 and closes #4

<img width="517" height="622" alt="image" src="https://github.com/user-attachments/assets/591735eb-4387-44a0-9373-ac8e4eb7ff48" />
<img width="517" height="518" alt="image" src="https://github.com/user-attachments/assets/ae1bdeec-0c6d-4bd9-93d5-397e1b8a5d89" />
<img width="517" height="398" alt="image" src="https://github.com/user-attachments/assets/1522f3d4-9230-4812-acc7-1cb40d332986" />
