### PR TITLE
fix: handle NULL is_failed in /brew/best query

### DIFF
--- a/app/routers/brew.py
+++ b/app/routers/brew.py
@@ -166,12 +166,17 @@ def _require_active_bean(request: Request, db: Session) -> Optional[Bean]:
 
 
 def _best_measurement(bean_id: str, db: Session) -> Optional[Measurement]:
-    """Return highest-taste measurement for a bean (excluding failed shots)."""
+    """Return highest-taste measurement for a bean (excluding failed shots).
+
+    Uses ``isnot(True)`` instead of ``== False`` so that rows where
+    ``is_failed`` is NULL (legacy data inserted without an explicit flag)
+    are still included.
+    """
     return (
         db.query(Measurement)
         .filter(
             Measurement.bean_id == bean_id,
-            Measurement.is_failed == False,  # noqa: E712
+            Measurement.is_failed.isnot(True),
         )
         .order_by(Measurement.taste.desc())
         .first()

--- a/tests/test_brew.py
+++ b/tests/test_brew.py
@@ -343,6 +343,29 @@ def test_show_best_excludes_failed_shots(active_client, sample_bean, db_session)
     assert "No shots yet" in response.text
 
 
+def test_show_best_includes_null_is_failed(active_client, sample_bean, db_session):
+    """GET /brew/best treats is_failed=NULL as not-failed (legacy data)."""
+    # Insert a measurement with is_failed=NULL (simulates legacy data)
+    m = Measurement(
+        bean_id=sample_bean.id,
+        recommendation_id=str(uuid.uuid4()),
+        grind_setting=20.0,
+        temperature=93.0,
+        dose_in=19.0,
+        target_yield=40.0,
+        taste=8.5,
+    )
+    # Bypass the ORM default by setting is_failed to None after construction
+    m.is_failed = None
+    db_session.add(m)
+    db_session.commit()
+
+    response = active_client.get("/brew/best")
+    assert response.status_code == 200
+    assert "8.5" in response.text
+    assert "Best Recipe" in response.text
+
+
 def test_show_best_displays_brew_ratio(active_client, sample_bean, db_session):
     """GET /brew/best shows the dose:yield brew ratio."""
     _seed_measurement(db_session, sample_bean.id, taste=8.5)


### PR DESCRIPTION
## Summary

- **Bug:** `/brew/best` returned 500 Internal Server Error when measurements had `is_failed=NULL` (legacy data inserted without the explicit boolean flag)
- **Root cause:** `_best_measurement()` used `Measurement.is_failed == False` which in SQL doesn't match `NULL` — all valid shots were excluded, returning `None`, and downstream template rendering crashed
- **Fix:** Changed to `Measurement.is_failed.isnot(True)` so both `False` and `NULL` are treated as "not failed"

## Changes

| File | Change |
|------|--------|
| `app/routers/brew.py` | `_best_measurement` filter: `== False` → `.isnot(True)` |
| `tests/test_brew.py` | Added `test_show_best_includes_null_is_failed` covering the NULL scenario |

## Testing

- 414 tests passing (413 existing + 1 new), zero regressions